### PR TITLE
#28 Add validation inputs to content fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Notety is a minimal notes app built with Angular. It lets you create, view, edit
 - Local persistence via `localStorage`
 - Accessible controls (aria-labels)
 - Modern Angular patterns: standalone components, signals, new control flow, reactive forms
+- Content limits and counters: Content field enforces 300 characters and up to 20 new lines, with live counters and tooltips
+- Notes list cards: Content section capped at 240px with a vertical scrollbar if overflow
 
 ## URLs
 
@@ -59,6 +61,21 @@ Notety is a minimal notes app built with Angular. It lets you create, view, edit
   - The input writes to `SearchService.term`; a debounced mirror `SearchService.debouncedTerm` updates after 300ms.
   - `NotesComponent` uses the debounced value to compute a filtered list.
 - Tuning: Adjust the debounce in [`shared/services/search.service.ts`](src/app/shared/services/search.service.ts) (`debounceMs`).
+
+## Content limits and counters
+
+- Limits: The content field allows up to 300 characters and a maximum of 20 new lines.
+- Live counters: Two counters show characters and new lines used (e.g., `123/300`, `3/20`). Hover for tooltips.
+- Enforcement:
+  - Typing: The Enter key is blocked after 20 new lines.
+  - Pasting: Excess new lines are trimmed automatically.
+- Validation messages: When invalid, an inline message appears aligned with the counters.
+- Where implemented:
+  - Form logic/UI: [`shared/note-form/NoteFormComponent`](src/app/shared/note-form/note-form.component.ts) and template [`note-form.component.html`](src/app/shared/note-form/note-form.component.html)
+  - Limits can be adjusted in `NoteFormComponent` via `MAX_CHARS` and `MAX_NEWLINES` constants.
+- Notes list layout:
+  - The content text inside each card is limited to a max height of 240px and becomes scrollable on overflow.
+  - See [`features/notes/notes.component.html`](src/app/features/notes/notes.component.html) and optional scrollbar styles in [`features/notes/notes.component.css`](src/app/features/notes/notes.component.css).
 
 ## Getting started
 

--- a/src/app/features/notes/notes.component.css
+++ b/src/app/features/notes/notes.component.css
@@ -1,1 +1,11 @@
-
+/* Optional: thin scrollbar for overflowing content area */
+.max-h-\[240px\]::-webkit-scrollbar {
+  width: 8px;
+}
+.max-h-\[240px\]::-webkit-scrollbar-thumb {
+  background-color: rgba(156, 163, 175, 0.8); /* gray-400 */
+  border-radius: 4px;
+}
+.max-h-\[240px\]::-webkit-scrollbar-track {
+  background-color: rgba(229, 231, 235, 0.6); /* gray-200 */
+}

--- a/src/app/features/notes/notes.component.html
+++ b/src/app/features/notes/notes.component.html
@@ -19,7 +19,9 @@
           {{ n.title ?? "Untitled" }}
         </h3>
       </header>
-      <p class="text-sm text-gray-700 whitespace-pre-line flex-1">
+      <p
+        class="text-sm text-gray-700 whitespace-pre-line flex-1 max-h-[240px] overflow-y-auto pr-2"
+      >
         {{ n.content }}
       </p>
       <div class="mt-3 flex items-center justify-end">

--- a/src/app/shared/note-form/note-form.component.html
+++ b/src/app/shared/note-form/note-form.component.html
@@ -22,6 +22,9 @@
       rows="8"
       formControlName="content"
       placeholder="Write your note..."
+      [attr.maxlength]="maxChars"
+      (keydown.enter)="onEnterKey($event)"
+      (input)="onContentInput()"
       [attr.aria-invalid]="
         form.controls.content.touched && form.controls.content.invalid
           ? true
@@ -32,12 +35,29 @@
         form.controls.content.touched && form.controls.content.invalid
       "
     ></textarea>
-    <p
-      *ngIf="form.controls.content.touched && form.controls.content.invalid"
-      class="mt-2 text-sm text-red-600"
-    >
-      Content is required.
-    </p>
+    <div class="mt-1 flex items-center justify-between text-xs">
+      <div class="text-red-600">
+        @if (form.controls.content.touched && form.controls.content.invalid) {
+        @if (form.controls.content.errors; as e) { @if (e['required']) { Content
+        is required. } @if (e['maxlength']) { Max {{ maxChars }} characters
+        only. } @if (e['maxNewLines']) { Max {{ maxNewlines }} new lines only. }
+        } }
+      </div>
+      <div class="flex items-center justify-end gap-3 text-gray-500">
+        <span
+          title="Characters (used/max)"
+          aria-label="Characters used out of maximum"
+          [class.text-red-600]="charCount > maxChars"
+          >{{ charCount }}/{{ maxChars }}</span
+        >
+        <span
+          title="New lines (used/max)"
+          aria-label="New lines used out of maximum"
+          [class.text-red-600]="newlineCount > maxNewlines"
+          >{{ newlineCount }}/{{ maxNewlines }}</span
+        >
+      </div>
+    </div>
   </div>
   <div class="flex items-center justify-end gap-2">
     <button

--- a/src/app/shared/note-form/note-form.component.ts
+++ b/src/app/shared/note-form/note-form.component.ts
@@ -120,7 +120,9 @@ export class NoteFormComponent {
       }
       out += ch;
     }
-    return out;
+      chars.push(ch);
+    }
+    return chars.join('');
   }
 
   private maxNewLinesValidator(maxNewlines: number): ValidatorFn {

--- a/src/app/shared/note-form/note-form.component.ts
+++ b/src/app/shared/note-form/note-form.component.ts
@@ -1,9 +1,12 @@
 import { Component, effect, input, output } from '@angular/core';
 import {
+  AbstractControl,
   FormBuilder,
   FormControl,
   FormGroup,
   ReactiveFormsModule,
+  ValidationErrors,
+  ValidatorFn,
   Validators,
 } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -22,6 +25,10 @@ export class NoteFormComponent {
   readonly cancel = output<void>();
 
   readonly form = this.initForm();
+
+  // limits
+  private static readonly MAX_CHARS = 300;
+  private static readonly MAX_NEWLINES = 20;
 
   constructor() {
     // react to input value changes and patch form
@@ -42,8 +49,12 @@ export class NoteFormComponent {
   }> {
     const fb = new FormBuilder();
     return fb.nonNullable.group({
-      title: [''],
-      content: ['', Validators.required],
+      title: fb.nonNullable.control<string>('', []),
+      content: fb.nonNullable.control<string>('', [
+        Validators.required,
+        Validators.maxLength(NoteFormComponent.MAX_CHARS),
+        this.maxNewLinesValidator(NoteFormComponent.MAX_NEWLINES),
+      ]),
     });
   }
 
@@ -54,5 +65,73 @@ export class NoteFormComponent {
       title: title?.trim() || undefined,
       content: content.trim(),
     });
+  }
+
+  // computed helpers
+  get contentControl(): FormControl<string> {
+    return this.form.controls.content;
+  }
+
+  get charCount(): number {
+    return this.contentControl.value?.length ?? 0;
+  }
+
+  get newlineCount(): number {
+    const v = this.contentControl.value ?? '';
+    // count '\n' occurrences
+    return (v.match(/\n/g) || []).length;
+  }
+
+  get maxChars(): number {
+    return NoteFormComponent.MAX_CHARS;
+  }
+
+  get maxNewlines(): number {
+    return NoteFormComponent.MAX_NEWLINES;
+  }
+
+  // event handlers to enforce limits during typing/paste
+  onEnterKey(e: Event): void {
+    const ev = e as KeyboardEvent;
+    if (this.newlineCount >= this.maxNewlines) {
+      ev.preventDefault();
+    }
+  }
+
+  onContentInput(): void {
+    const v = this.contentControl.value ?? '';
+    const limited = this.limitNewlines(v, this.maxNewlines);
+    if (limited !== v) {
+      this.contentControl.setValue(limited);
+    }
+  }
+
+  private limitNewlines(value: string, maxNewlines: number): string {
+    let count = 0;
+    let out = '';
+    for (let i = 0; i < value.length; i++) {
+      const ch = value[i];
+      if (ch === '\n') {
+        if (count >= maxNewlines) {
+          // skip extra newlines
+          continue;
+        }
+        count++;
+      }
+      out += ch;
+    }
+    return out;
+  }
+
+  private maxNewLinesValidator(maxNewlines: number): ValidatorFn {
+    return (
+      control: AbstractControl<string, string>
+    ): ValidationErrors | null => {
+      const v = (control?.value as string) ?? '';
+      const count = (v.match(/\n/g) || []).length;
+      return count > maxNewlines
+        ? { maxNewLines: { requiredMax: maxNewlines, actual: count } }
+        : null;
+    };
   }
 }

--- a/src/app/shared/note-form/note-form.component.ts
+++ b/src/app/shared/note-form/note-form.component.ts
@@ -108,7 +108,7 @@ export class NoteFormComponent {
 
   private limitNewlines(value: string, maxNewlines: number): string {
     let count = 0;
-    let out = '';
+    const chars = [];
     for (let i = 0; i < value.length; i++) {
       const ch = value[i];
       if (ch === '\n') {
@@ -118,8 +118,6 @@ export class NoteFormComponent {
         }
         count++;
       }
-      out += ch;
-    }
       chars.push(ch);
     }
     return chars.join('');


### PR DESCRIPTION
This pull request introduces input limits and improved validation for the note content field, along with UI enhancements to support these changes. The main improvements are enforcing character and newline limits, providing real-time feedback to users, and making the notes list more readable with better scrolling.

**Input limits and validation improvements:**

* Added maximum character (300) and newline (20) limits for the note content field in `NoteFormComponent`, enforced both via validators and input event handlers. [[1]](diffhunk://#diff-89cde7da3eb7b3121615582e98cba0bcc6537ccc7ccae04deaf58fe0abec3583R29-R32) [[2]](diffhunk://#diff-89cde7da3eb7b3121615582e98cba0bcc6537ccc7ccae04deaf58fe0abec3583L45-R57) [[3]](diffhunk://#diff-89cde7da3eb7b3121615582e98cba0bcc6537ccc7ccae04deaf58fe0abec3583R69-R136)
* Updated the note form UI to display live counters for characters and newlines, and show specific validation error messages for exceeding limits. [[1]](diffhunk://#diff-d8d002dc60d8eebfa56d11f480a96d595c508452908d13e37e3e07b4075ea8dbR25-R27) [[2]](diffhunk://#diff-d8d002dc60d8eebfa56d11f480a96d595c508452908d13e37e3e07b4075ea8dbL35-R60)

**UI/UX enhancements:**

* Made the note content area in the notes list scrollable with a maximum height, and added a custom thin scrollbar for better readability when content overflows. [[1]](diffhunk://#diff-4cbb0a6e51956bd9e2a15e5c1dfc955fbbc5233cd25ced36a61d659ce623399bL22-R24) [[2]](diffhunk://#diff-caa7c024b2619fde65619f20ec2e0a160fb8b178041770087c08678c8a1a021fL1-R11)