### PR TITLE
Add sensitive data warning banner and console log for security notices

### DIFF
--- a/.github/instructions/angular.instructions.md
+++ b/.github/instructions/angular.instructions.md
@@ -85,6 +85,7 @@ Here is a link to the most recent Angular style guide https://angular.dev/style-
 ### Components
 
 - Keep components small and focused on a single responsibility
+- Components should still separate logic (TS), styles (CSS) and templates (HTML)
 - Use `input()` signal instead of decorators, learn more here https://angular.dev/guide/components/inputs
 - Use `output()` function instead of decorators, learn more here https://angular.dev/guide/components/outputs
 - Use `computed()` for derived state learn more about signals here https://angular.dev/guide/signals.
@@ -113,3 +114,8 @@ Here is a link to the most recent Angular style guide https://angular.dev/style-
 - Design services around a single responsibility
 - Use the `providedIn: 'root'` option for singleton services
 - Use the `inject()` function instead of constructor injection
+
+### Styling
+
+- Use tailwindcss for all styling needs
+- Avoid using global styles, prefer component-scoped styles

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Notety is a minimal notes app built with Angular. It lets you create, view, edit, and remove notes locally (no backend). Notes are persisted in your browser’s localStorage.
 
+> Security Notice: Do not store passwords, API keys, tokens, personal, regulated, or otherwise sensitive / confidential information in Notety. All data is stored unencrypted in your browser (localStorage) and can be read by anyone with access to this device or the page context.
+
 ## Features
 
 - Create notes with optional title and required content

--- a/src/app/features/notes/notes.component.html
+++ b/src/app/features/notes/notes.component.html
@@ -9,6 +9,7 @@
       + New
     </a>
   </div>
+  <app-sensitive-warning-banner />
   <div class="grid grid-cols-3 gap-4">
     @for (n of filteredNotes(); track $index; let i = $index) {
     <article

--- a/src/app/features/notes/notes.component.ts
+++ b/src/app/features/notes/notes.component.ts
@@ -11,13 +11,14 @@ import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 import { NotesService } from './notes.service';
 import { NoteList } from '../models/note.model';
 import { NoteDetailsComponent } from './note-details.component';
+import { SensitiveWarningBannerComponent } from '../../shared/sensitive-warning/sensitive-warning-banner.component';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { SearchService } from '../../shared/services/search.service';
 import { CategoriesService } from '../../shared/services/categories.service';
 
 @Component({
   selector: 'app-notes',
-  imports: [RouterLink, NoteDetailsComponent],
+  imports: [RouterLink, NoteDetailsComponent, SensitiveWarningBannerComponent],
   templateUrl: './notes.component.html',
   styleUrl: './notes.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/sensitive-warning/sensitive-warning-banner.component.css
+++ b/src/app/shared/sensitive-warning/sensitive-warning-banner.component.css
@@ -1,0 +1,1 @@
+/* Tailwind utility classes are used directly in the template; this file intentionally left minimal for potential future overrides. */

--- a/src/app/shared/sensitive-warning/sensitive-warning-banner.component.html
+++ b/src/app/shared/sensitive-warning/sensitive-warning-banner.component.html
@@ -8,7 +8,7 @@
   <div class="flex-1 leading-snug">
     <span class="font-semibold tracking-tight">Security notice:</span>
     <span class="font-normal">
-      Do not store passwords, tokens, personal or otherwise sensitive /
+      Do not store passwords, tokens, personal or otherwise sensitive or
       confidential data. Notes are stored
       <span
         class="font-medium underline decoration-amber-400/70 underline-offset-2"

--- a/src/app/shared/sensitive-warning/sensitive-warning-banner.component.html
+++ b/src/app/shared/sensitive-warning/sensitive-warning-banner.component.html
@@ -1,0 +1,33 @@
+@if (visible()) {
+<div
+  role="alert"
+  aria-live="polite"
+  class="group relative mb-4 flex items-start gap-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 shadow-sm ring-1 ring-inset ring-amber-200/40"
+>
+  <span class="mt-0.5 select-none text-base" aria-hidden="true">⚠️</span>
+  <div class="flex-1 leading-snug">
+    <span class="font-semibold tracking-tight">Security notice:</span>
+    <span class="font-normal">
+      Do not store passwords, tokens, personal or otherwise sensitive /
+      confidential data. Notes are stored
+      <span
+        class="font-medium underline decoration-amber-400/70 underline-offset-2"
+        >unencrypted</span
+      >
+      in your browser (localStorage) and may be readable by anyone with access
+      to this device or the page context.
+    </span>
+  </div>
+  <button
+    type="button"
+    (click)="dismiss()"
+    aria-label="Dismiss security notice"
+    class="ml-2 inline-flex items-center rounded border border-transparent bg-amber-200/60 px-2 py-1 text-xs font-medium text-amber-900 backdrop-blur-sm transition hover:bg-amber-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500 focus-visible:ring-offset-1 active:bg-amber-300"
+  >
+    Dismiss
+  </button>
+  <div
+    class="pointer-events-none absolute inset-0 rounded-md shadow-[0_0_0_1px_rgba(251,191,36,0.35)] group-hover:shadow-[0_0_0_1px_rgba(245,158,11,0.55)] transition"
+  ></div>
+</div>
+}

--- a/src/app/shared/sensitive-warning/sensitive-warning-banner.component.spec.ts
+++ b/src/app/shared/sensitive-warning/sensitive-warning-banner.component.spec.ts
@@ -1,0 +1,58 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  SensitiveWarningBannerComponent,
+  SENSITIVE_WARNING_KEY,
+} from './sensitive-warning-banner.component';
+
+function queryByRole(root: HTMLElement, role: string): HTMLElement | null {
+  return root.querySelector(`[role="${role}"]`);
+}
+
+describe('SensitiveWarningBannerComponent', () => {
+  beforeEach(() => {
+    try {
+      localStorage.removeItem(SENSITIVE_WARNING_KEY);
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('shows the banner by default when not dismissed', () => {
+    const fixture = TestBed.configureTestingModule({
+      imports: [SensitiveWarningBannerComponent],
+    }).createComponent(SensitiveWarningBannerComponent);
+    fixture.detectChanges();
+    const alert = queryByRole(fixture.nativeElement, 'alert');
+    expect(alert).toBeTruthy();
+    expect(fixture.nativeElement.textContent).toMatch(/Security notice/i);
+  });
+
+  it('hides after dismiss and sets localStorage', () => {
+    const fixture = TestBed.configureTestingModule({
+      imports: [SensitiveWarningBannerComponent],
+    }).createComponent(SensitiveWarningBannerComponent);
+    fixture.detectChanges();
+    const button: HTMLButtonElement | null =
+      fixture.nativeElement.querySelector('button');
+    expect(button).toBeTruthy();
+    button!.click();
+    fixture.detectChanges();
+    const alert = queryByRole(fixture.nativeElement, 'alert');
+    expect(alert).toBeNull();
+    expect(localStorage.getItem(SENSITIVE_WARNING_KEY)).toBe('1');
+  });
+
+  it('does not render when already dismissed', () => {
+    try {
+      localStorage.setItem(SENSITIVE_WARNING_KEY, '1');
+    } catch {
+      /* ignore */
+    }
+    const fixture = TestBed.configureTestingModule({
+      imports: [SensitiveWarningBannerComponent],
+    }).createComponent(SensitiveWarningBannerComponent);
+    fixture.detectChanges();
+    const alert = queryByRole(fixture.nativeElement, 'alert');
+    expect(alert).toBeNull();
+  });
+});

--- a/src/app/shared/sensitive-warning/sensitive-warning-banner.component.ts
+++ b/src/app/shared/sensitive-warning/sensitive-warning-banner.component.ts
@@ -1,0 +1,32 @@
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+
+// LocalStorage key constant (exported for test access)
+export const SENSITIVE_WARNING_KEY = 'notety.sensitiveWarning.dismissed';
+
+@Component({
+  selector: 'app-sensitive-warning-banner',
+  standalone: true,
+  templateUrl: './sensitive-warning-banner.component.html',
+  styleUrls: ['./sensitive-warning-banner.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SensitiveWarningBannerComponent {
+  readonly visible = signal(!this.isDismissed());
+
+  private isDismissed(): boolean {
+    try {
+      return !!localStorage.getItem(SENSITIVE_WARNING_KEY);
+    } catch {
+      return false; // safest: show banner
+    }
+  }
+
+  dismiss(): void {
+    try {
+      localStorage.setItem(SENSITIVE_WARNING_KEY, '1');
+    } catch {
+      /* ignore */
+    }
+    this.visible.set(false);
+  }
+}

--- a/src/app/shared/utils/security-warning.spec.ts
+++ b/src/app/shared/utils/security-warning.spec.ts
@@ -1,0 +1,22 @@
+import {
+  logSensitiveDataConsoleWarning,
+  SENSITIVE_WARNING_CONSOLE_FLAG,
+} from './security-warning';
+
+describe('logSensitiveDataConsoleWarning', () => {
+  beforeEach(() => {
+    // reset the flag between tests
+    delete (globalThis as Record<string, unknown>)[
+      SENSITIVE_WARNING_CONSOLE_FLAG
+    ];
+  });
+
+  it('logs exactly once per session flag', () => {
+    const spy = jest.spyOn(console, 'warn').mockImplementation(() => void 0);
+    logSensitiveDataConsoleWarning();
+    expect(spy).toHaveBeenCalledTimes(1);
+    logSensitiveDataConsoleWarning();
+    expect(spy).toHaveBeenCalledTimes(1); // still 1 — no duplicate
+    spy.mockRestore();
+  });
+});

--- a/src/app/shared/utils/security-warning.ts
+++ b/src/app/shared/utils/security-warning.ts
@@ -1,0 +1,21 @@
+/**
+ * Logs a one-time security warning to the developer console reminding users not to store sensitive data.
+ * The banner UI handles end-user messaging; this reinforces it for anyone inspecting DevTools.
+ */
+const FLAG = '__NOTETY_SENSITIVE_WARNING_LOGGED__';
+
+export function logSensitiveDataConsoleWarning(): void {
+  const g = globalThis as Record<string, unknown>;
+  if (g[FLAG]) return; // already logged this session
+  g[FLAG] = true;
+  try {
+    console.warn(
+      'Notety security notice: Do NOT store passwords, API keys, tokens, personal, regulated, or otherwise sensitive/confidential data here. Notes are stored unencrypted in localStorage and may be readable by scripts or anyone with device access.'
+    );
+  } catch {
+    /* ignore */
+  }
+}
+
+// Re-export flag name for potential testing/debug (not currently used in tests directly)
+export const SENSITIVE_WARNING_CONSOLE_FLAG = FLAG;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,10 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { App } from './app/app';
+import { logSensitiveDataConsoleWarning } from './app/shared/utils/security-warning';
+
+// One-time console warning for security (reinforces in-app banner)
+logSensitiveDataConsoleWarning();
 
 bootstrapApplication(App, appConfig).catch((err: unknown): void =>
   console.error(err)


### PR DESCRIPTION
This pull request introduces a comprehensive security warning system to Notety, ensuring users are informed not to store sensitive data in the app. The changes include a new dismissible warning banner in the UI, a one-time developer console warning, and updated documentation. Additionally, Angular style instructions are clarified, and TailwindCSS is now recommended for styling.

**Security warning enhancements:**

* Added a dismissible `SensitiveWarningBannerComponent` to the notes UI, warning users not to store sensitive/confidential data since notes are stored unencrypted in localStorage. Banner visibility is persisted using localStorage. (`src/app/shared/sensitive-warning/sensitive-warning-banner.component.ts`, `src/app/shared/sensitive-warning/sensitive-warning-banner.component.html`, `src/app/features/notes/notes.component.html`, `src/app/features/notes/notes.component.ts`) [[1]](diffhunk://#diff-a09f3fb09bfc30a50293dd80363b1f076577fa595353468473d6864cf04e46fbR1-R32) [[2]](diffhunk://#diff-2959b2dca63d7a0c0a11a523f5a0e8d516383036f9b203939613f790c256461dR1-R33) [[3]](diffhunk://#diff-4cbb0a6e51956bd9e2a15e5c1dfc955fbbc5233cd25ced36a61d659ce623399bR12) [[4]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aR14-R21)
* Introduced a one-time security warning in the developer console at app startup to reinforce the message for anyone inspecting DevTools. (`src/app/shared/utils/security-warning.ts`, `src/main.ts`) [[1]](diffhunk://#diff-913b5b287901d5f87e74e447c9436ff6ae8550df65c0bc32539d19b61430cdeaR1-R21) [[2]](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR4-R7)
* Added automated tests for both the banner component and the console warning logic. (`src/app/shared/sensitive-warning/sensitive-warning-banner.component.spec.ts`, `src/app/shared/utils/security-warning.spec.ts`) [[1]](diffhunk://#diff-eb7ac767cfed9c5f3cc28248b2e255a11a268d4d2703e7fb178d8c23f1a496c9R1-R58) [[2]](diffhunk://#diff-7a4c7aa8b4aa1ea02e1ee0d40f207e121baf46b47d009f4988bcdeadfbb9d76cR1-R22)
* Updated the `README.md` to include a clear security notice about the risks of storing sensitive data in Notety.

**Documentation and style guide updates:**

* Clarified Angular component and service structure in the instructions, and added a recommendation to use TailwindCSS for all styling, discouraging global styles. (`.github/instructions/angular.instructions.md`) [[1]](diffhunk://#diff-c8a0b06fede7cfb08d6599eeb06c15ce59dfd7972b44f9ac9734796e7a5a68daR88) [[2]](diffhunk://#diff-c8a0b06fede7cfb08d6599eeb06c15ce59dfd7972b44f9ac9734796e7a5a68daR117-R121)