### PR TITLE
Fix note content display by changing div to paragraph for better sema…

### DIFF
--- a/src/app/features/notes/note-details.component.html
+++ b/src/app/features/notes/note-details.component.html
@@ -32,8 +32,8 @@
     </a>
     }
   </div>
-  <div
-    class="prose prose-sm max-w-none text-gray-800 whitespace-pre-line"
+  <p
+    class="prose prose-sm max-w-none text-gray-800 whitespace-pre-line wrap-break-word"
     [innerHTML]="note()?.content | linkify"
-  ></div>
+  ></p>
 </div>


### PR DESCRIPTION
This pull request updates the way note content is rendered in the `note-details.component.html` file to improve semantic HTML and text wrapping behavior.

**Rendering improvements:**

* Changed the note content container from a `div` to a `p` element for better semantic structure and accessibility.
* Added the `wrap-break-word` class to ensure long words in note content wrap correctly, improving readability.…ntics #55