### PR TITLE
#67 adjust to 1000 characters limit of the notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Notety is a minimal notes app built with Angular. It lets you create, view, edit
 - Local persistence via `localStorage`
 - Accessible controls (aria-labels)
 - Modern Angular patterns: standalone components, signals, new control flow, reactive forms
-- Content limits and counters: Content field enforces 300 characters and up to 20 new lines, with live counters and tooltips
+- Content limits and counters: Content field enforces 1000 characters and up to 20 new lines, with live counters and tooltips
 - Notes list cards: Content section capped at 240px with a vertical scrollbar if overflow
 - Responsive notes grid (1 → 2 → 3 → 4 columns at sm / lg / xl breakpoints)
 - Manual backup & restore: ad‑hoc JSON export/import (localStorage only; no sync or encryption)
@@ -174,8 +174,8 @@ Key implementation points
 
 ## Content limits and counters
 
-- Limits: The content field allows up to 300 characters and a maximum of 20 new lines.
-- Live counters: Two counters show characters and new lines used (e.g., `123/300`, `3/20`). Hover for tooltips.
+- Limits: The content field allows up to 1000 characters and a maximum of 20 new lines.
+- Live counters: Two counters show characters and new lines used (e.g., `123/1000`, `3/20`). Hover for tooltips.
 - Enforcement:
   - Typing: The Enter key is blocked after 20 new lines.
   - Pasting: Excess new lines are trimmed automatically.

--- a/src/app/shared/note-form/note-form.component.ts
+++ b/src/app/shared/note-form/note-form.component.ts
@@ -40,7 +40,7 @@ export class NoteFormComponent {
   protected readonly categoriesSvc = inject(CategoriesService);
 
   // limits
-  private static readonly MAX_CHARS = 300;
+  private static readonly MAX_CHARS = 1000;
   private static readonly MAX_NEWLINES = 20;
 
   constructor() {


### PR DESCRIPTION
This pull request updates the content limits for notes in the Notety app, increasing the maximum allowed characters per note from 300 to 1000. The change is reflected in both the code and documentation to ensure consistency for users and developers.

Content limit increase:

* Increased the maximum character limit for note content from 300 to 1000 in the `NoteFormComponent` (`src/app/shared/note-form/note-form.component.ts`).

Documentation updates:

* Updated the feature summary and implementation details in the `README.md` to reflect the new 1000 character limit for notes, including examples in the live counters section. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L177-R178)