### PR TITLE
66 add category pills for notes list when listing all categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Notety is a minimal notes app built with Angular. It lets you create, view, edit
 - Remove notes from the list
 - Search notes (title and content) using the navbar search input with a 300ms debounce; hidden on the add and edit page
 - Categories: add/edit categories, pick a category per note, and filter the list by the selected category; seeded defaults and local persistence
+- Category pills: each note card shows a compact pill with its category name for quick at‑a‑glance scanning while browsing all notes
 - Local persistence via `localStorage`
 - Accessible controls (aria-labels)
 - Modern Angular patterns: standalone components, signals, new control flow, reactive forms
@@ -155,12 +156,48 @@ Organize notes by category and quickly filter the list.
   - Each note has a required `categoryId`.
   - When creating a note, the form defaults to the “Personal” category if available, else the first category.
   - Notes saved previously without a category are migrated to “Personal” (or the first/created category) on load.
+  - When listing notes ("All Categories" selected) each note card displays its category as a small pill for rapid visual grouping.
 
 Key implementation points
 
 - Service: `CategoriesService` manages a `categories` signal, a `selectedId`, derives the selected category, and persists changes.
 - Navbar: the dropdown binds to `CategoriesService`, and the modal is wired through outputs to add or edit names.
 - Modal: `CategoryModalComponent` provides title by mode (Add/Edit), enforces required + max length (20), and emits the name on save.
+- Pills: `PillsComponent` renders a styled Tailwind pill (rounded border, indigo text) showing the category name inside each note card.
+
+## Category Pills
+
+Small visual “pills” show the category of each note directly in the notes grid when you are viewing all categories. This improves scan speed by letting you visually cluster related notes without opening filters.
+
+Behavior:
+
+- Only rendered when a note has a resolvable `categoryName` and the list view includes that note (e.g., the “All Categories” filter or any filter where categories are still relevant).
+- Hidden placeholder container keeps layout stable if a category is missing (rare after migrations).
+
+Implementation:
+
+- Lightweight standalone component: `shared/pills/PillsComponent` (uses Angular signals via `input.required()`)
+- Pure Tailwind utility styling; no additional CSS logic.
+- Added inside each note card header/action row in `features/notes/notes.component.html`:
+
+  ```html
+  @if (n.categoryName) {<app-pills [text]="n.categoryName" />}
+  ```
+
+Accessibility & UX:
+
+- `title` attribute on the `<span>` exposes the full category name on hover for truncated/long names (though names are short by validation).
+- Non-interactive (purely informational) to reduce tab stops.
+
+Customization ideas:
+
+- Add color‑coding per category (e.g., map hash of name to a Tailwind color class)
+- Make pills clickable to set the active category filter
+- Add an icon or emoji prefix stored with category metadata in a future schema version
+
+Testing:
+
+- See `shared/pills/pills.component.spec.ts` for creation and class presence tests.
 
 ## Search
 

--- a/src/app/features/models/note.model.ts
+++ b/src/app/features/models/note.model.ts
@@ -5,6 +5,7 @@ export interface Note {
   categoryId: string;
   createdAt: Date;
   updatedAt?: Date;
+  categoryName?: string; // populated when listing notes
 }
 
 export type NoteList = Note[];

--- a/src/app/features/notes/notes.component.html
+++ b/src/app/features/notes/notes.component.html
@@ -40,22 +40,30 @@
         2xl:min-h-[245px]`"
         [innerHTML]="n.content | linkify"
       ></p>
-      <div class="mt-3 flex items-center justify-end">
-        <a
-          [routerLink]="['/notes']"
-          [queryParams]="{ view: n.id }"
-          aria-label="View"
-          class="text-sm text-indigo-600 hover:text-indigo-700 mr-4"
-          >View</a
-        >
-        <button
-          type="button"
-          (click)="removeNote(i)"
-          aria-label="Remove"
-          class="text-sm text-red-600 hover:text-red-700"
-        >
-          Remove
-        </button>
+      <div class="mt-3 flex items-center justify-between">
+        @if(n.title){<app-pills [text]="n.categoryName ?? ''"></app-pills
+        >}@else{
+        <div>
+          <!-- Placeholder for empty categories -->
+        </div>
+        }
+        <div class="flex items-center justify-end">
+          <a
+            [routerLink]="['/notes']"
+            [queryParams]="{ view: n.id }"
+            aria-label="View"
+            class="text-sm text-indigo-600 hover:text-indigo-700 mr-4"
+            >View</a
+          >
+          <button
+            type="button"
+            (click)="removeNote(i)"
+            aria-label="Remove"
+            class="text-sm text-red-600 hover:text-red-700"
+          >
+            Remove
+          </button>
+        </div>
       </div>
     </article>
     }

--- a/src/app/features/notes/notes.component.html
+++ b/src/app/features/notes/notes.component.html
@@ -41,8 +41,7 @@
         [innerHTML]="n.content | linkify"
       ></p>
       <div class="mt-3 flex items-center justify-between">
-        @if(n.title){<app-pills [text]="n.categoryName ?? ''"></app-pills
-        >}@else{
+        @if (n.categoryName) {<app-pills [text]="n.categoryName" />} @else {
         <div>
           <!-- Placeholder for empty categories -->
         </div>

--- a/src/app/features/notes/notes.component.spec.ts
+++ b/src/app/features/notes/notes.component.spec.ts
@@ -152,7 +152,10 @@ describe('NotesComponent syncQuery effect', () => {
         { provide: SearchService, useValue: { debouncedTerm: signal('') } },
         {
           provide: CategoriesService,
-          useValue: { selectedId: signal<string | null>(null) },
+          useValue: {
+            selectedId: signal<string | null>(null),
+            getName: jest.fn(),
+          },
         },
         {
           provide: ActivatedRoute,
@@ -270,7 +273,10 @@ describe('NotesComponent filteredNotes computed', () => {
         { provide: SearchService, useValue: { debouncedTerm: signal('') } },
         {
           provide: CategoriesService,
-          useValue: { selectedId: signal<string | null>(null) },
+          useValue: {
+            selectedId: signal<string | null>(null),
+            getName: jest.fn(),
+          },
         },
         {
           provide: ActivatedRoute,
@@ -292,6 +298,7 @@ describe('NotesComponent filteredNotes computed', () => {
     };
     const cats = TestBed.inject(CategoriesService) as unknown as {
       selectedId: ReturnType<typeof signal<string | null>>;
+      getName: (id: string) => string | null;
     };
     return { fixture, component, search, cats };
   }

--- a/src/app/features/notes/notes.component.ts
+++ b/src/app/features/notes/notes.component.ts
@@ -9,13 +9,14 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 import { NotesService } from './notes.service';
-import { NoteList } from '../models/note.model';
+import { Note, NoteList } from '../models/note.model';
 import { NoteDetailsComponent } from './note-details.component';
 import { SensitiveWarningBannerComponent } from '../../shared/sensitive-warning/sensitive-warning-banner.component';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { SearchService } from '../../shared/services/search.service';
 import { CategoriesService } from '../../shared/services/categories.service';
 import { LinkifyPipe } from '../../shared/pipe/linkify/linkify-pipe';
+import { PillsComponent } from '../../shared/pills/pills.component';
 
 @Component({
   selector: 'app-notes',
@@ -24,6 +25,7 @@ import { LinkifyPipe } from '../../shared/pipe/linkify/linkify-pipe';
     NoteDetailsComponent,
     SensitiveWarningBannerComponent,
     LinkifyPipe,
+    PillsComponent,
   ],
   templateUrl: './notes.component.html',
   styleUrl: './notes.component.css',
@@ -51,14 +53,21 @@ export class NotesComponent implements OnDestroy {
       : list;
 
     if (!term) {
-      return byCategory;
+      return byCategory.map((n: Note) => ({
+        ...n,
+        categoryName: this.categories.getName(n.categoryId),
+      }));
     }
 
-    return byCategory.filter(
+    const byTitleAndContent = byCategory.filter(
       (n) =>
         (n.title ?? '').toLowerCase().includes(term) ||
         n.content.toLowerCase().includes(term)
     );
+    return byTitleAndContent.map((n) => ({
+      ...n,
+      categoryName: this.categories.getName(n.categoryId),
+    })); // return copies to ensure reactivity;
   });
 
   // dialog state

--- a/src/app/shared/pills/pills.component.css
+++ b/src/app/shared/pills/pills.component.css
@@ -1,0 +1,1 @@
+/* No custom styles needed - using Tailwind classes directly in template */

--- a/src/app/shared/pills/pills.component.html
+++ b/src/app/shared/pills/pills.component.html
@@ -1,6 +1,6 @@
 <span
   title="{{ text() }}"
-  class="block max-w-30 cursor-default overflow-hidden rounded-full bg-gray-500 px-3 py-0.5 text-xs leading-5 font-medium text-ellipsis whitespace-nowrap text-white"
+  class="block cursor-default overflow-hidden rounded-full border border-purple-600 px-3 py-0.5 text-xs leading-5 font-medium text-ellipsis whitespace-nowrap text-purple-600"
 >
   {{ text() }}
 </span>

--- a/src/app/shared/pills/pills.component.html
+++ b/src/app/shared/pills/pills.component.html
@@ -1,6 +1,6 @@
 <span
   title="{{ text() }}"
-  class="block cursor-default overflow-hidden rounded-full border border-purple-600 px-3 py-0.5 text-xs leading-5 font-medium text-ellipsis whitespace-nowrap text-purple-600"
+  class="block cursor-default overflow-hidden rounded-full border border-indigo-600 px-3 py-0.5 text-xs leading-5 font-medium text-ellipsis whitespace-nowrap text-indigo-600"
 >
   {{ text() }}
 </span>

--- a/src/app/shared/pills/pills.component.html
+++ b/src/app/shared/pills/pills.component.html
@@ -1,0 +1,6 @@
+<span
+  title="{{ text() }}"
+  class="block max-w-30 cursor-default overflow-hidden rounded-full bg-gray-500 px-3 py-0.5 text-xs leading-5 font-medium text-ellipsis whitespace-nowrap text-white"
+>
+  {{ text() }}
+</span>

--- a/src/app/shared/pills/pills.component.spec.ts
+++ b/src/app/shared/pills/pills.component.spec.ts
@@ -23,7 +23,7 @@ describe('PillsComponent', () => {
     fixture.detectChanges();
 
     const pillElement = fixture.nativeElement.querySelector('span');
-    expect(pillElement.textContent).toBe('Test Pill');
+    expect(pillElement.textContent).toBe(' Test Pill\n');
   });
 
   it('should have tailwind classes for styling', () => {
@@ -32,8 +32,8 @@ describe('PillsComponent', () => {
 
     const pillElement = fixture.nativeElement.querySelector('span');
     expect(pillElement).toBeTruthy();
-    expect(pillElement.classList.contains('bg-gray-500')).toBe(true);
-    expect(pillElement.classList.contains('text-white')).toBe(true);
+    expect(pillElement.classList.contains('text-indigo-600')).toBe(true);
+    expect(pillElement.classList.contains('border-indigo-600')).toBe(true);
     expect(pillElement.classList.contains('rounded-full')).toBe(true);
   });
 });

--- a/src/app/shared/pills/pills.component.spec.ts
+++ b/src/app/shared/pills/pills.component.spec.ts
@@ -1,0 +1,39 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PillsComponent } from './pills.component';
+
+describe('PillsComponent', () => {
+  let component: PillsComponent;
+  let fixture: ComponentFixture<PillsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PillsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PillsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should display the provided text', () => {
+    fixture.componentRef.setInput('text', 'Test Pill');
+    fixture.detectChanges();
+
+    const pillElement = fixture.nativeElement.querySelector('span');
+    expect(pillElement.textContent).toBe('Test Pill');
+  });
+
+  it('should have tailwind classes for styling', () => {
+    fixture.componentRef.setInput('text', 'Test');
+    fixture.detectChanges();
+
+    const pillElement = fixture.nativeElement.querySelector('span');
+    expect(pillElement).toBeTruthy();
+    expect(pillElement.classList.contains('bg-gray-500')).toBe(true);
+    expect(pillElement.classList.contains('text-white')).toBe(true);
+    expect(pillElement.classList.contains('rounded-full')).toBe(true);
+  });
+});

--- a/src/app/shared/pills/pills.component.ts
+++ b/src/app/shared/pills/pills.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+@Component({
+  selector: 'app-pills',
+  standalone: true,
+  templateUrl: './pills.component.html',
+  styleUrls: ['./pills.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PillsComponent {
+  readonly text = input.required<string>();
+}

--- a/src/app/shared/services/categories.service.ts
+++ b/src/app/shared/services/categories.service.ts
@@ -61,6 +61,11 @@ export class CategoriesService {
     this.categories.set(categories);
   }
 
+  public getName(categoryId: string): string | null {
+    const category = this.categories().find((c) => c.id === categoryId);
+    return category ? category.Name : null;
+  }
+
   selectCategory(id: string | null): void {
     if (id === null) {
       this.selectedId.set(null);

--- a/src/app/shared/services/categories.service.ts
+++ b/src/app/shared/services/categories.service.ts
@@ -63,7 +63,7 @@ export class CategoriesService {
 
   public getName(categoryId: string): string | null {
     const category = this.categories().find((c) => c.id === categoryId);
-    return category ? category.Name : null;
+    return category?.Name || null;
   }
 
   selectCategory(id: string | null): void {


### PR DESCRIPTION
This pull request adds a new "category pill" visual indicator to each note card in the notes grid, making it easier to visually scan and group notes by category. It introduces a reusable `PillsComponent` for displaying category names, updates the notes listing to include category names, and ensures proper testing and documentation. The changes also update the `CategoriesService` to provide category name lookups and adjust the notes model and tests accordingly.

**Category Pill Feature:**

- Added a new `PillsComponent` (`shared/pills/pills.component.ts`, `.html`, `.css`, `.spec.ts`) that renders a styled, accessible pill showing the category name for each note. This is a standalone Angular component using Tailwind classes and Angular signals. [[1]](diffhunk://#diff-39ca963985005afe5da5c1606ede1748cca4db702c4656cc2b6f351f5426cfd6R1-R12) [[2]](diffhunk://#diff-bdade9f504b2a8984279588f76c2f9edc9bf73a06a8e0fd47b10673b31388b2dR1-R6) [[3]](diffhunk://#diff-18e7e024198a9c00a920741ede4f2a30dcd4077202e0182db78b8200c950341bR1) [[4]](diffhunk://#diff-34a5abcfba7c984997121ab8b892f072c4fbb994e743e796a74e4c59a6e80b93R1-R39)
- Updated the notes grid (`notes.component.html`, `notes.component.ts`) to display a category pill for each note with a resolvable category, and included a placeholder for notes without a category to maintain layout stability. [[1]](diffhunk://#diff-4cbb0a6e51956bd9e2a15e5c1dfc955fbbc5233cd25ced36a61d659ce623399bL43-R49) [[2]](diffhunk://#diff-4cbb0a6e51956bd9e2a15e5c1dfc955fbbc5233cd25ced36a61d659ce623399bR66) [[3]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aL12-R19) [[4]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aR28) [[5]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aL54-R70)

**Model and Service Updates:**

- Extended the `Note` model to include an optional `categoryName` property, populated when listing notes.
- Added a `getName` method to `CategoriesService` to resolve category names by ID, and updated the notes listing logic to attach the category name to each note. [[1]](diffhunk://#diff-2e91a447b835eaa3eacd4c98f72163251cd863c622e89181344c5b9510a96d42R64-R68) [[2]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aL54-R70)

**Testing Improvements:**

- Updated tests and mocks in `notes.component.spec.ts` to account for the new `getName` method and the presence of the `categoryName` property on notes. [[1]](diffhunk://#diff-0e534f7472baab39a597035ba63b640e4cdcd1b54d7c5a9edf004672d10c1ab4L155-R158) [[2]](diffhunk://#diff-0e534f7472baab39a597035ba63b640e4cdcd1b54d7c5a9edf004672d10c1ab4L273-R279) [[3]](diffhunk://#diff-0e534f7472baab39a597035ba63b640e4cdcd1b54d7c5a9edf004672d10c1ab4R301)

**Documentation:**

- Expanded the `README.md` with a new "Category Pills" section, describing the feature, its behavior, implementation details, accessibility considerations, and ideas for future enhancements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159-R200)