### PR TITLE
#77 not aligned notes card footer

### DIFF
--- a/src/app/features/notes/notes.component.html
+++ b/src/app/features/notes/notes.component.html
@@ -18,7 +18,9 @@
       class="bg-white rounded-lg shadow-sm border border-gray-200 p-4 flex flex-col"
     >
       <header class="mb-2">
-        <h3 class="text-base font-medium text-gray-900">
+        <h3
+          class="block cursor-default text-base font-medium truncate text-gray-900"
+        >
           {{ n.title ?? "Untitled" }}
         </h3>
       </header>

--- a/src/app/features/notes/notes.component.html
+++ b/src/app/features/notes/notes.component.html
@@ -19,6 +19,7 @@
     >
       <header class="mb-2">
         <h3
+          [title]="n.title ?? 'Untitled'"
           class="block cursor-default text-base font-medium truncate text-gray-900"
         >
           {{ n.title ?? "Untitled" }}


### PR DESCRIPTION
This pull request makes a small UI improvement to the notes feature by enhancing the display of note titles. The change ensures that long or missing note titles are handled more gracefully for users.

- Improved note title display:
  * Updated the `<h3>` element in `notes.component.html` to show the full note title as a tooltip (`[title]="n.title ?? 'Untitled'"`), apply truncation for long titles, and ensure accessibility and clarity for untitled notes.