### PR TITLE
#79 fix note saving functionality to prevent removal of other notes

### DIFF
--- a/src/app/features/notes/add-note.component.ts
+++ b/src/app/features/notes/add-note.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { NoteFormComponent } from '../../shared/note-form/note-form.component';
 import { NotesService } from './notes.service';
 import { createGuid } from '../../shared/utils/guid';
+import { CategoriesService } from '../../shared/services/categories.service';
 
 @Component({
   selector: 'app-add-note',
@@ -17,6 +18,7 @@ import { createGuid } from '../../shared/utils/guid';
 })
 export class AddNoteComponent {
   private readonly notes = inject(NotesService);
+  private readonly categories = inject(CategoriesService);
   private readonly router = inject(Router);
 
   async onSave(value: {
@@ -31,6 +33,7 @@ export class AddNoteComponent {
       categoryId: value.categoryId,
       createdAt: new Date(),
     });
+    this.categories.selectedId.set(value.categoryId);
     await this.router.navigate(['/', 'notes']);
   }
 

--- a/src/app/features/notes/notes.service.spec.ts
+++ b/src/app/features/notes/notes.service.spec.ts
@@ -146,8 +146,6 @@ describe('NotesService update', () => {
     const list = svc.notes();
     expect(list.length).toBe(1);
     expect(list[0].id).toBe('n1');
-
-    jest.advanceTimersByTime(200);
     expect(setItemSpy).toHaveBeenCalled();
   });
 

--- a/src/app/features/notes/notes.service.ts
+++ b/src/app/features/notes/notes.service.ts
@@ -9,13 +9,6 @@ export class NotesService {
 
   readonly notes = signal<NoteList>(this.loadFromStorageOrSeed());
 
-  // No injector needed: service is providedIn 'root' (app-lifetime); effect cleans up its debounce timer
-  private readonly persistEffect = effect((onCleanup) => {
-    const current = this.notes();
-    const handle = setTimeout(() => this.saveToStorage(current), 150);
-    onCleanup(() => clearTimeout(handle));
-  });
-
   private loadFromStorageOrSeed(): NoteList {
     try {
       const raw = localStorage.getItem(this.storageKey);
@@ -70,8 +63,10 @@ export class NotesService {
     return created ? created.id : '';
   }
 
-  add(note: Note): void {
-    this.notes.update((list) => [note, ...list]);
+  public add(note: Note): void {
+    const updatedList = [note, ...this.notes()];
+    this.notes.set(updatedList);
+    this.saveToStorage(updatedList);
   }
 
   removeAt(index: number): void {
@@ -82,18 +77,23 @@ export class NotesService {
     return this.notes().find((n) => n.id === id);
   }
 
-  update(id: string, changes: Partial<Omit<Note, 'id' | 'createdAt'>>): void {
-    this.notes.update((list) =>
-      list.map((n) =>
-        n.id === id
-          ? {
-              ...n,
-              ...changes,
-              updatedAt: new Date(),
-            }
-          : n
-      )
+  public update(
+    id: string,
+    changes: Partial<Omit<Note, 'id' | 'createdAt'>>
+  ): void {
+    const updatedList = this.notes().map((n) =>
+      n.id === id
+        ? {
+            ...n,
+            ...changes,
+            updatedAt: new Date(),
+          }
+        : n
     );
+
+    this.notes.set(updatedList);
+
+    this.saveToStorage(updatedList);
   }
 
   /**

--- a/src/app/features/notes/notes.service.ts
+++ b/src/app/features/notes/notes.service.ts
@@ -71,6 +71,7 @@ export class NotesService {
 
   removeAt(index: number): void {
     this.notes.update((list) => list.filter((_, i) => i !== index));
+    this.saveToStorage(this.notes());
   }
 
   findById(id: string): Note | undefined {


### PR DESCRIPTION
This pull request introduces several improvements to the notes feature, focusing on ensuring that category selection is updated when adding a note, and making the notes service more reliable by persisting changes to storage immediately. It also cleans up some test code and removes an unused debouncing effect.

**Category selection improvements:**

* When a new note is added using `AddNoteComponent`, the selected category is now updated via `CategoriesService` to reflect the user's choice. (`src/app/features/notes/add-note.component.ts`) [[1]](diffhunk://#diff-11b12c9ffad2bd51d9eb3ae001037230dc3023370cd5430d3b0d817fddbbf979R6) [[2]](diffhunk://#diff-11b12c9ffad2bd51d9eb3ae001037230dc3023370cd5430d3b0d817fddbbf979R21) [[3]](diffhunk://#diff-11b12c9ffad2bd51d9eb3ae001037230dc3023370cd5430d3b0d817fddbbf979R36)

**Notes persistence and service reliability:**

* The `NotesService` now immediately saves changes to local storage when notes are added, removed, or updated, instead of relying on a debounced effect. This ensures data consistency and reduces the risk of data loss. (`src/app/features/notes/notes.service.ts`) [[1]](diffhunk://#diff-dd41efc68261c03287b3a17a9a5d35f24d5f54afd524d974bcfffe7b2868770eL12-L18) [[2]](diffhunk://#diff-dd41efc68261c03287b3a17a9a5d35f24d5f54afd524d974bcfffe7b2868770eL73-R97)

**Testing improvements:**

* Simplified the `NotesService` update test by removing unnecessary timer advancement, since persistence is now immediate. (`src/app/features/notes/notes.service.spec.ts`)