### PR TITLE
73 add warning dialog when importing notes json

### DIFF
--- a/src/app/features/notes/notes.component.html
+++ b/src/app/features/notes/notes.component.html
@@ -92,7 +92,7 @@
         accept="application/json"
         class="hidden"
         #restoreFile
-        (change)="restoreNotes(restoreFile)"
+        (change)="onRestoreFileSelected(restoreFile)"
       />
     </label>
     }
@@ -135,6 +135,19 @@
     (confirm)="confirmDelete(deleteDialog().noteIndex)"
     (cancel)="closeDeleteDialog()"
     (close)="closeDeleteDialog()"
+  />
+  }
+
+  <!-- Restore Confirmation Dialog -->
+  @if(restoreDialog().show){
+  <app-confirmation-dialog
+    [title]="`Restore from Backup`"
+    message="Restoring will overwrite your current notes and categories with the contents of the selected backup. This action cannot be undone. Proceed?"
+    confirmButtonText="Restore"
+    cancelButtonText="Cancel"
+    (confirm)="confirmRestore()"
+    (cancel)="closeRestoreDialog()"
+    (close)="closeRestoreDialog()"
   />
   }
 

--- a/src/app/features/notes/notes.component.spec.ts
+++ b/src/app/features/notes/notes.component.spec.ts
@@ -1,13 +1,18 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NotesComponent } from './notes.component';
-import { Router, ActivatedRoute, convertToParamMap } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
 import { signal } from '@angular/core';
-import { NotesService } from './notes.service';
-import { SearchService } from '../../shared/services/search.service';
-import { CategoriesService } from '../../shared/services/categories.service';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  provideRouter,
+  Router,
+} from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 import { of } from 'rxjs';
+import { CategoriesService } from '../../shared/services/categories.service';
+import { SearchService } from '../../shared/services/search.service';
 import { Note } from '../models/note.model';
+import { NotesComponent } from './notes.component';
+import { NotesService } from './notes.service';
 
 describe('NotesComponent closeDialog', () => {
   let fixture: ComponentFixture<NotesComponent>;
@@ -347,5 +352,165 @@ describe('NotesComponent filteredNotes computed', () => {
     cats.selectedId.set('cat-2');
     search.debouncedTerm.set('alpha');
     expect(component.filteredNotes().map((n) => n.id)).toEqual(['b2']);
+  });
+});
+
+describe('NotesComponent restoreNotes', () => {
+  const makeRouteStub = () => ({
+    queryParamMap: of(convertToParamMap({})),
+    snapshot: { queryParamMap: convertToParamMap({}) },
+  });
+
+  let originalFileReader: typeof FileReader;
+  type NotesSvcStub = {
+    notes: ReturnType<typeof signal<Note[]>>;
+    findById: jest.Mock;
+    removeAt: jest.Mock;
+    replaceAll: jest.Mock;
+  };
+  type CategoriesSvcStub = {
+    selectedId: ReturnType<typeof signal<string | null>>;
+    getName: jest.Mock;
+    replaceAll: jest.Mock;
+  };
+  let notesSvcStub: NotesSvcStub;
+  let categoriesSvcStub: CategoriesSvcStub;
+
+  beforeEach(() => {
+    originalFileReader = globalThis.FileReader;
+    // fresh stubs per test
+    notesSvcStub = {
+      notes: signal([]),
+      findById: jest.fn(),
+      removeAt: jest.fn(),
+      replaceAll: jest.fn(),
+    };
+    categoriesSvcStub = {
+      selectedId: signal<string | null>(null),
+      getName: jest.fn(),
+      replaceAll: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    // restore FileReader
+    globalThis.FileReader = originalFileReader;
+    jest.useRealTimers();
+  });
+
+  function mockFileReaderWithResult(result: string | ArrayBuffer) {
+    const mock = {
+      onload: null as FileReader['onload'],
+      result: result as FileReader['result'],
+      readAsText: jest.fn((_blob: Blob) => {
+        // Immediately invoke onload with preset result
+        if (typeof mock.onload === 'function') {
+          mock.onload({} as ProgressEvent<FileReader>);
+        }
+      }),
+    } as unknown as FileReader;
+
+    // Provide a constructor-like function for FileReader
+    const FakeFileReader = function () {
+      return mock;
+    } as unknown as typeof FileReader;
+    globalThis.FileReader = FakeFileReader;
+    return mock;
+  }
+
+  async function configureAndCreate() {
+    await TestBed.configureTestingModule({
+      imports: [NotesComponent],
+      providers: [
+        {
+          provide: NotesService,
+          useValue: notesSvcStub as unknown as NotesService,
+        },
+        { provide: SearchService, useValue: { debouncedTerm: signal('') } },
+        {
+          provide: CategoriesService,
+          useValue: categoriesSvcStub as unknown as CategoriesService,
+        },
+        { provide: ActivatedRoute, useValue: makeRouteStub() },
+        provideRouter([]),
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(NotesComponent);
+    const component = fixture.componentInstance;
+    fixture.detectChanges();
+    return { fixture, component };
+  }
+
+  it('restores notes and categories from valid backup and shows success', async () => {
+    const { component } = await configureAndCreate();
+
+    const backupJson = JSON.stringify({
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      categories: [{ id: 'cat-1', Name: 'Work' }],
+      notes: [
+        {
+          id: 'n1',
+          title: 'T',
+          content: 'C',
+          categoryId: 'cat-1',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      ],
+    });
+
+    mockFileReaderWithResult(backupJson);
+
+    const fakeInput = {
+      files: [new Blob([backupJson], { type: 'application/json' })],
+      value: 'dummy',
+    } as unknown as HTMLInputElement;
+
+    component.restoreNotes(fakeInput);
+
+    expect(notesSvcStub.replaceAll).toHaveBeenCalledTimes(1);
+    expect(notesSvcStub.replaceAll).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'n1', title: 'T', content: 'C' }),
+      ])
+    );
+    expect(categoriesSvcStub.replaceAll).toHaveBeenCalledTimes(1);
+    expect(categoriesSvcStub.replaceAll).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ id: 'cat-1' })])
+    );
+
+    expect(component.successAlertMessage()).toBe('Restore completed.');
+    expect(fakeInput.value).toBe('');
+  });
+
+  it('shows error and does not replace when backup format is invalid', async () => {
+    jest.useFakeTimers();
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const { component } = await configureAndCreate();
+
+    const invalidBackup = JSON.stringify({ version: 1, exportedAt: 'x' });
+    mockFileReaderWithResult(invalidBackup);
+
+    const fakeInput = {
+      files: [new Blob([invalidBackup], { type: 'application/json' })],
+      value: 'dummy',
+    } as unknown as HTMLInputElement;
+
+    component.restoreNotes(fakeInput);
+
+    expect(notesSvcStub.replaceAll).not.toHaveBeenCalled();
+    expect(categoriesSvcStub.replaceAll).not.toHaveBeenCalled();
+    expect(component.alertMessage()).toBe('Failed to restore.');
+
+    // It schedules auto-hide after 4s
+    jest.advanceTimersByTime(4000);
+    expect(component.alertMessage()).toBeNull();
+    expect(fakeInput.value).toBe('');
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/src/app/features/notes/notes.component.spec.ts
+++ b/src/app/features/notes/notes.component.spec.ts
@@ -513,4 +513,104 @@ describe('NotesComponent restoreNotes', () => {
 
     consoleErrorSpy.mockRestore();
   });
+
+  it('opens restore confirmation dialog on file selection and proceeds on confirm', async () => {
+    const { fixture, component } = await configureAndCreate();
+
+    const backupJson = JSON.stringify({
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      categories: [{ id: 'cat-1', Name: 'Work' }],
+      notes: [
+        {
+          id: 'n1',
+          title: 'T',
+          content: 'C',
+          categoryId: 'cat-1',
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    });
+    mockFileReaderWithResult(backupJson);
+
+    const fakeInput = {
+      files: [new Blob([backupJson], { type: 'application/json' })],
+      value: 'dummy',
+    } as unknown as HTMLInputElement;
+
+    // Simulate file selection action
+    component.onRestoreFileSelected(fakeInput);
+    fixture.detectChanges();
+
+    expect(component.restoreDialog().show).toBe(true);
+
+    // Find restore confirmation dialog and click confirm
+    const dialogEl: HTMLElement | null = fixture.nativeElement.querySelector(
+      'app-confirmation-dialog'
+    );
+    expect(dialogEl).toBeTruthy();
+    const buttons = Array.from(dialogEl!.querySelectorAll('button'));
+    const confirmBtn = buttons.find((b) =>
+      /restore/i.test(b.textContent || '')
+    );
+    expect(confirmBtn).toBeTruthy();
+    confirmBtn!.click();
+    fixture.detectChanges();
+
+    // Should have called replaceAll via restoreNotes
+    expect(notesSvcStub.replaceAll).toHaveBeenCalled();
+    expect(categoriesSvcStub.replaceAll).toHaveBeenCalled();
+  });
+
+  it('cancels restore: dialog closes and input is cleared, no replace called', async () => {
+    const { fixture, component } = await configureAndCreate();
+
+    const backupJson = JSON.stringify({
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      categories: [],
+      notes: [],
+    });
+    mockFileReaderWithResult(backupJson);
+
+    // Create an input-like object we can observe value on
+    const fakeInput = {
+      files: [new Blob([backupJson], { type: 'application/json' })],
+      value: 'dummy',
+    } as unknown as HTMLInputElement;
+
+    component.onRestoreFileSelected(fakeInput);
+    fixture.detectChanges();
+    expect(component.restoreDialog().show).toBe(true);
+
+    // Click cancel on confirmation dialog
+    const dialogEl: HTMLElement | null = fixture.nativeElement.querySelector(
+      'app-confirmation-dialog'
+    );
+    expect(dialogEl).toBeTruthy();
+    const buttons = Array.from(dialogEl!.querySelectorAll('button'));
+    const cancelBtn = buttons.find((b) => /cancel/i.test(b.textContent || ''));
+    expect(cancelBtn).toBeTruthy();
+    cancelBtn!.click();
+    fixture.detectChanges();
+
+    expect(component.restoreDialog().show).toBe(false);
+    // Input should be cleared
+    expect(fakeInput.value).toBe('');
+    // No replace calls should have happened
+    expect(notesSvcStub.replaceAll).not.toHaveBeenCalled();
+    expect(categoriesSvcStub.replaceAll).not.toHaveBeenCalled();
+  });
+
+  it('does not open restore dialog when no file is selected', async () => {
+    const { component } = await configureAndCreate();
+
+    const fakeInput = {
+      files: [],
+      value: '',
+    } as unknown as HTMLInputElement;
+
+    component.onRestoreFileSelected(fakeInput);
+    expect(component.restoreDialog().show).toBe(false);
+  });
 });

--- a/src/app/features/notes/notes.component.ts
+++ b/src/app/features/notes/notes.component.ts
@@ -85,6 +85,10 @@ export class NotesComponent implements OnDestroy {
     show: false,
     noteIndex: null as number | null,
   });
+  readonly restoreDialog = signal({
+    show: false,
+    input: null as HTMLInputElement | null,
+  });
 
   // floating action button state
   readonly fabOpen = signal(false);
@@ -132,7 +136,34 @@ export class NotesComponent implements OnDestroy {
     }
   }
 
-  restoreNotes(input: HTMLInputElement): void {
+  public onRestoreFileSelected(input: HTMLInputElement): void {
+    const file = input.files?.[0];
+    if (!file) return;
+    // Open confirmation dialog; keep a reference to the input to use on confirm
+    this.restoreDialog.set({ show: true, input });
+  }
+
+  public closeRestoreDialog(): void {
+    const current = this.restoreDialog();
+    if (current.input) {
+      // Clear the file selection when canceling/closing
+      current.input.value = '';
+    }
+    this.restoreDialog.set({ show: false, input: null });
+  }
+
+  public confirmRestore(): void {
+    const current = this.restoreDialog();
+    if (!current.input) {
+      this.restoreDialog.set({ show: false, input: null });
+      return;
+    }
+    // Hide dialog before performing restore
+    this.restoreDialog.set({ show: false, input: null });
+    this.restoreNotes(current.input);
+  }
+
+  public restoreNotes(input: HTMLInputElement): void {
     const file = input.files?.[0];
     if (!file) return;
     const reader = new FileReader();

--- a/src/app/features/notes/notes.component.ts
+++ b/src/app/features/notes/notes.component.ts
@@ -7,17 +7,17 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
-import { NotesService } from './notes.service';
-import { Note, NoteList } from '../models/note.model';
-import { NoteDetailsComponent } from './note-details.component';
-import { SensitiveWarningBannerComponent } from '../../shared/sensitive-warning/sensitive-warning-banner.component';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { SearchService } from '../../shared/services/search.service';
-import { CategoriesService } from '../../shared/services/categories.service';
-import { LinkifyPipe } from '../../shared/pipe/linkify/linkify-pipe';
-import { PillsComponent } from '../../shared/pills/pills.component';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ConfirmationDialogComponent } from '../../shared/confirmation-dialog/confirmation-dialog.component';
+import { PillsComponent } from '../../shared/pills/pills.component';
+import { LinkifyPipe } from '../../shared/pipe/linkify/linkify-pipe';
+import { SensitiveWarningBannerComponent } from '../../shared/sensitive-warning/sensitive-warning-banner.component';
+import { CategoriesService } from '../../shared/services/categories.service';
+import { SearchService } from '../../shared/services/search.service';
+import { Note } from '../models/note.model';
+import { NoteDetailsComponent } from './note-details.component';
+import { NotesService } from './notes.service';
 
 @Component({
   selector: 'app-notes',
@@ -136,9 +136,24 @@ export class NotesComponent implements OnDestroy {
     const file = input.files?.[0];
     if (!file) return;
     const reader = new FileReader();
+
     reader.onload = () => {
       try {
-        const parsed = JSON.parse(String(reader.result));
+        const res = reader.result;
+        if (res == null) {
+          throw new Error('Failed to read file contents.');
+        }
+        let text: string;
+        if (typeof res === 'string') {
+          text = res;
+        } else if (res instanceof ArrayBuffer) {
+          // Guard against accidental ArrayBuffer results; decode as UTF-8
+          text = new TextDecoder('utf-8').decode(new Uint8Array(res));
+        } else {
+          // As a last resort, use Blob/text
+          throw new Error('Unsupported file content type.');
+        }
+        const parsed = JSON.parse(text);
         if (!parsed || !Array.isArray(parsed.notes)) {
           throw new Error('Invalid backup format');
         }
@@ -149,7 +164,7 @@ export class NotesComponent implements OnDestroy {
       } catch (e) {
         console.error(e);
         this.alertMessage.set('Failed to restore.');
-        this.autoHideSuccessAlert();
+        this.autoHideAlert();
       } finally {
         input.value = '';
       }


### PR DESCRIPTION
This pull request enhances the backup restore functionality in the `NotesComponent` by introducing a confirmation dialog before restoring, improving the robustness of file handling, and adding comprehensive tests for the restore flow. These changes improve user safety (preventing accidental data loss), reliability, and test coverage.

**Restore Flow Improvements:**

* Added a confirmation dialog (`app-confirmation-dialog`) that appears when a backup file is selected for restore. The restore process only proceeds if the user confirms, reducing the risk of accidental overwrites. (`src/app/features/notes/notes.component.html`, `src/app/features/notes/notes.component.ts`) [[1]](diffhunk://#diff-4cbb0a6e51956bd9e2a15e5c1dfc955fbbc5233cd25ced36a61d659ce623399bR141-R153) [[2]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aR88-R91) [[3]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aL135-R187)
* Refactored the restore logic to separate file selection (`onRestoreFileSelected`), dialog handling (`confirmRestore`, `closeRestoreDialog`), and the actual restore operation (`restoreNotes`). The input element is cleared appropriately on cancel or after restore. (`src/app/features/notes/notes.component.html`, `src/app/features/notes/notes.component.ts`) [[1]](diffhunk://#diff-4cbb0a6e51956bd9e2a15e5c1dfc955fbbc5233cd25ced36a61d659ce623399bL95-R95) [[2]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aL135-R187)

**File Handling Robustness:**

* Improved file reading by handling both string and `ArrayBuffer` results from `FileReader`, and providing clear error handling for unsupported types or empty results. (`src/app/features/notes/notes.component.ts`)

**Testing Enhancements:**

* Added extensive unit tests for the restore flow, covering confirmation dialog behavior, successful and failed restores, file input clearing, and edge cases (such as no file selected or canceling the dialog). (`src/app/features/notes/notes.component.spec.ts`)
* Refactored and organized imports in `notes.component.ts` and `notes.component.spec.ts` for clarity and maintainability. (`src/app/features/notes/notes.component.ts`, `src/app/features/notes/notes.component.spec.ts`) [[1]](diffhunk://#diff-e1a1505f34383b856e4283d34e1a3251077761b13b3703d1c4bf61f627c38c5aL10-R20) [[2]](diffhunk://#diff-0e534f7472baab39a597035ba63b640e4cdcd1b54d7c5a9edf004672d10c1ab4R1-R15)

These changes collectively make the restore feature safer, more robust, and well-tested.