### PR TITLE
refactor: improve notes service to load from localStorage and handle …

### DIFF
--- a/src/app/features/notes/notes.service.spec.ts
+++ b/src/app/features/notes/notes.service.spec.ts
@@ -1,10 +1,10 @@
 import { TestBed } from '@angular/core/testing';
-import { NotesService } from './notes.service';
 import {
   CategoriesService,
   Category,
 } from '../../shared/services/categories.service';
 import { Note } from '../models/note.model';
+import { NotesService } from './notes.service';
 
 describe('NotesService update', () => {
   const STORAGE_KEY = 'notety.notes';
@@ -158,5 +158,114 @@ describe('NotesService update', () => {
 
     const missing = svc.findById('nope');
     expect(missing).toBeUndefined();
+  });
+
+  it('add() refreshes from localStorage first, then prepends the new note', () => {
+    const svc = TestBed.runInInjectionContext(() => new NotesService());
+
+    // Simulate another tab writing a newer list to storage after service initialization
+    const latestRaw = [
+      {
+        id: 'n10',
+        title: 'Latest 10',
+        content: 'Latest content 10',
+        categoryId: 'cat-1',
+        createdAt: new Date('2024-04-01T00:00:00.000Z'),
+      },
+      {
+        id: 'n2',
+        title: 'Title 2 (latest)',
+        content: 'Content 2 (latest)',
+        categoryId: 'cat-2',
+        createdAt: new Date('2024-02-01T00:00:00.000Z'),
+      },
+    ];
+    getItemSpy.mockImplementation((key: string) =>
+      key === STORAGE_KEY ? JSON.stringify(makeStored(latestRaw)) : null
+    );
+
+    const newNote: Note = {
+      id: 'n11',
+      title: 'Newest',
+      content: 'Newest content',
+      categoryId: 'cat-1',
+      createdAt: new Date('2024-05-01T00:00:00.000Z'),
+    };
+
+    svc.add(newNote);
+
+    // Expected: notes are refreshed to latestRaw, then new note is prepended
+    const expectedAfterRefresh = latestRaw.map((n) => ({
+      id: n.id,
+      title: n.title,
+      content: n.content,
+      categoryId: n.categoryId,
+      createdAt: n.createdAt,
+      updatedAt: undefined,
+    }));
+    const list = svc.notes();
+    expect(list.length).toBe(1 + expectedAfterRefresh.length);
+    expect(list[0]).toEqual(newNote);
+    expect(list.slice(1)).toEqual(expectedAfterRefresh);
+    expect(setItemSpy).toHaveBeenCalled();
+  });
+
+  it('update() refreshes from localStorage first and applies changes on the latest snapshot', () => {
+    const svc = TestBed.runInInjectionContext(() => new NotesService());
+
+    // The latest snapshot modifies n2 content compared to initial
+    const latestRaw = [
+      {
+        id: 'n1',
+        title: 'Title 1',
+        content: 'Content 1',
+        categoryId: 'cat-1',
+        createdAt: new Date('2024-01-01T00:00:00.000Z'),
+      },
+      {
+        id: 'n2',
+        title: 'Title 2',
+        content: 'Content 2 (from another tab)',
+        categoryId: 'cat-2',
+        createdAt: new Date('2024-02-01T00:00:00.000Z'),
+      },
+    ];
+    getItemSpy.mockImplementation((key: string) =>
+      key === STORAGE_KEY ? JSON.stringify(makeStored(latestRaw)) : null
+    );
+
+    svc.update('n2', { title: 'New Title 2' });
+
+    const updated = svc.findById('n2')!;
+    expect(updated.title).toBe('New Title 2');
+    // Content should remain from the latest snapshot (not the original in-memory)
+    expect(updated.content).toBe('Content 2 (from another tab)');
+    expect(updated.updatedAt).toBeInstanceOf(Date);
+    expect(setItemSpy).toHaveBeenCalled();
+  });
+
+  it('gracefully handles null storage on refresh before add/update', () => {
+    const svc = TestBed.runInInjectionContext(() => new NotesService());
+
+    // Force refresh to return null
+    getItemSpy.mockImplementation(() => null);
+
+    const before = svc.notes();
+    svc.update('n1', { title: 'T1 updated' });
+    // Should have updated in-memory without replacing with an empty list
+    const afterUpdate = svc.findById('n1')!;
+    expect(afterUpdate.title).toBe('T1 updated');
+
+    const newNote: Note = {
+      id: 'n999',
+      title: 'T999',
+      content: 'C999',
+      categoryId: 'cat-1',
+      createdAt: new Date('2024-06-01T00:00:00.000Z'),
+    };
+    svc.add(newNote);
+    const afterAdd = svc.notes();
+    expect(afterAdd.length).toBe(before.length + 1); // added exactly one
+    expect(afterAdd[0]).toEqual(newNote);
   });
 });

--- a/src/app/features/notes/notes.service.ts
+++ b/src/app/features/notes/notes.service.ts
@@ -1,19 +1,20 @@
-import { Injectable, effect, signal, inject } from '@angular/core';
-import { Note, NoteList } from '../models/note.model';
+import { Injectable, inject, signal } from '@angular/core';
 import { CategoriesService } from '../../shared/services/categories.service';
+import { Note, NoteList } from '../models/note.model';
 
 @Injectable({ providedIn: 'root' })
 export class NotesService {
   private readonly storageKey = 'notety.notes';
   private readonly categories = inject(CategoriesService);
 
-  readonly notes = signal<NoteList>(this.loadFromStorageOrSeed());
+  readonly notes = signal<NoteList>(this.seed());
 
-  private loadFromStorageOrSeed(): NoteList {
+  // Attempts to load notes from localStorage; returns null when unavailable or on parse failure
+  private loadFromStorage(): NoteList | null {
     try {
       const raw = localStorage.getItem(this.storageKey);
       if (!raw) {
-        return [];
+        return null;
       }
       const parsed = JSON.parse(raw) as Array<
         Omit<Note, 'createdAt' | 'updatedAt' | 'categoryId'> & {
@@ -32,8 +33,14 @@ export class NotesService {
         updatedAt: n.updatedAt ? new Date(n.updatedAt) : undefined,
       }));
     } catch {
-      return [];
+      return null;
     }
+  }
+
+  // Seeds initial state using storage contents when present; otherwise returns an empty list
+  private seed(): NoteList {
+    const fromStorage = this.loadFromStorage();
+    return fromStorage ?? [];
   }
 
   private saveToStorage(list: NoteList): void {
@@ -64,6 +71,12 @@ export class NotesService {
   }
 
   public add(note: Note): void {
+    // Ensure we operate on the latest snapshot from localStorage
+    const latest = this.loadFromStorage();
+    if (latest) {
+      this.notes.set(latest);
+    }
+
     const updatedList = [note, ...this.notes()];
     this.notes.set(updatedList);
     this.saveToStorage(updatedList);
@@ -82,6 +95,12 @@ export class NotesService {
     id: string,
     changes: Partial<Omit<Note, 'id' | 'createdAt'>>
   ): void {
+    // Ensure we operate on the latest snapshot from localStorage
+    const latest = this.loadFromStorage();
+    if (latest) {
+      this.notes.set(latest);
+    }
+
     const updatedList = this.notes().map((n) =>
       n.id === id
         ? {


### PR DESCRIPTION
This pull request improves the robustness of the `NotesService` by ensuring that add and update operations always work with the latest data from `localStorage`, preventing data loss or overwrites when multiple tabs are open. It also adds comprehensive tests for these behaviors and refactors the initialization logic for clarity.

**Testing improvements:**

- Added tests to verify that `add()` and `update()` methods refresh from `localStorage` before mutating the notes list, ensuring that changes from other tabs are not lost. Also added tests to check graceful handling of missing or null storage.

**NotesService logic and structure:**

- Refactored storage loading: split the logic into `loadFromStorage()` (returns `null` if storage is missing or invalid) and `seed()` (initializes from storage or as an empty list), improving clarity and error handling. [[1]](diffhunk://#diff-dd41efc68261c03287b3a17a9a5d35f24d5f54afd524d974bcfffe7b2868770eL1-R17) [[2]](diffhunk://#diff-dd41efc68261c03287b3a17a9a5d35f24d5f54afd524d974bcfffe7b2868770eL35-R45)
- Updated the `add()` and `update()` methods to always refresh the notes list from `localStorage` before making changes, so the service operates on the most recent snapshot. [[1]](diffhunk://#diff-dd41efc68261c03287b3a17a9a5d35f24d5f54afd524d974bcfffe7b2868770eR74-R79) [[2]](diffhunk://#diff-dd41efc68261c03287b3a17a9a5d35f24d5f54afd524d974bcfffe7b2868770eR98-R103)…null cases #86